### PR TITLE
SBJsonWriter infinity check

### DIFF
--- a/Classes/SBJsonWriter.m
+++ b/Classes/SBJsonWriter.m
@@ -106,7 +106,7 @@ static NSMutableCharacterSet *kEscapeChars;
             [self addErrorWithCode:EUNSUPPORTED description:@"NaN is not a valid number in JSON"];
             return NO;
 
-        } else if ([fragment isEqualToNumber:[NSNumber numberWithDouble:INFINITY]] || [fragment isEqualToNumber:[NSNumber numberWithDouble:-INFINITY]]) {
+        } else if (isinf([fragment doubleValue])) {
             [self addErrorWithCode:EUNSUPPORTED description:@"Infinity is not a valid number in JSON"];
             return NO;
 


### PR DESCRIPTION
Presently, infinity is checked in appendValue: into: using
    [fragment isEqualToNumber:[NSNumber numberWithDouble:INFINITY]]

This can cause problems because it's possible for 
    [[NSNumber numberWithFloat: 0] isEqualToNumber: [NSNumber numberWithDouble: INFINITY]] 
to return YES.  To check for infinity, you should change this line (line 109, SBJsonWriter.m) from:

```
 } else if ([fragment isEqualToNumber:[NSNumber numberWithDouble:INFINITY]] || [fragment isEqualToNumber:[NSNumber numberWithDouble:-INFINITY]]) {
```

to
    } else if (isinf([fragment doubleValue])) {
