### PR TITLE
add retain keyword, because of "self.error = nil" in dealloc 

### DIFF
--- a/Classes/SBJsonStreamWriter.m
+++ b/Classes/SBJsonStreamWriter.m
@@ -34,7 +34,7 @@
 #import "SBProxyForJson.h"
 
 @interface SBJsonStreamWriter ()
-@property NSString *error;
+@property(retain) NSString *error;
 @property(readonly) NSObject **states;
 @property(readonly) NSUInteger depth;
 @property(readonly) NSOutputStream *stream;


### PR DESCRIPTION
Can you check this warning?
