### PR TITLE
add __weak to @property definition for state object to address build error when supporting gc

### DIFF
--- a/Classes/SBJsonStreamParser.h
+++ b/Classes/SBJsonStreamParser.h
@@ -96,7 +96,7 @@ typedef enum {
 	NSString *error;
 }
 
-@property (nonatomic, assign) SBJsonStreamParserState *state; /// Private
+@property (nonatomic, assign) __weak SBJsonStreamParserState *state; /// Private
 @property (nonatomic, readonly, retain) SBStateStack *stateStack; /// Private
 
 /**

--- a/Classes/SBJsonStreamWriter.h
+++ b/Classes/SBJsonStreamWriter.h
@@ -88,7 +88,7 @@
     BOOL sortKeys, humanReadable;
 }
 
-@property (nonatomic, assign) SBJsonStreamWriterState *state; /// Internal
+@property (nonatomic, assign) __weak SBJsonStreamWriterState *state; /// Internal
 @property (nonatomic, readonly, retain) SBStateStack *stateStack; /// Internal 
 
 /**


### PR DESCRIPTION
With the most recent commit (7303bab8dd982d6b893c9e5ba494a4dc2ef234da) when the source is compiled in a project supporting garbage collection (-fobjc-gc), the following build error occurs in SBJsonStreamWriter.m and SBJsonStreamParser.m

`SBJsonStreamParser.m: error: Semantic Issue: Property 'state' must be declared __weak to match existing ivar 'state' with __weak attribute`

`SBJsonStreamWriter.m: error: Semantic Issue: Property 'state' must be declared __weak to match existing ivar 'state' with __weak attribute`

I've forked and made the change suggested by the compiler - that being said this is a fairly 'dumb' fix and may not be the right way to do it
