### PR TITLE
Xcode 4 archiving and 32-bit compatibility

### DIFF
--- a/Classes/SBJsonParser.h
+++ b/Classes/SBJsonParser.h
@@ -38,7 +38,10 @@
 
  */
 
-@interface SBJsonParser : NSObject
+@interface SBJsonParser : NSObject {
+	NSUInteger maxDepth;
+	NSString *error;
+}
 
 /**
  @brief The maximum recursing depth.

--- a/Classes/SBJsonStreamParser.h
+++ b/Classes/SBJsonStreamParser.h
@@ -136,6 +136,14 @@ typedef enum {
 	NSMutableArray *stack;
 	
 	SBJsonStreamParserType currentType;
+	
+	NSUInteger levelsToSkip;
+	BOOL supportMultipleDocuments;
+	NSString *error;
+	id<SBJsonStreamParserDelegate> delegate;
+	NSUInteger maxDepth;
+	SBJsonStreamParserState *state;
+	NSMutableArray *stateStack;
 }
 
 @property (nonatomic, assign) SBJsonStreamParserState *state; // Private

--- a/Classes/SBJsonStreamParserAccumulator.h
+++ b/Classes/SBJsonStreamParserAccumulator.h
@@ -30,7 +30,9 @@
 #import <Foundation/Foundation.h>
 #import "SBJsonStreamParser.h"
 
-@interface SBJsonStreamParserAccumulator : NSObject <SBJsonStreamParserDelegate>
+@interface SBJsonStreamParserAccumulator : NSObject <SBJsonStreamParserDelegate> {
+	id value;
+}
 
 @property (copy) id value;
 

--- a/Classes/SBJsonStreamWriter.h
+++ b/Classes/SBJsonStreamWriter.h
@@ -84,6 +84,14 @@
 
 @interface SBJsonStreamWriter : NSObject {
     NSMutableDictionary *cache;
+	
+	NSString *error;
+	NSUInteger maxDepth;
+	SBJsonStreamWriterState *state;
+	NSMutableArray *stateStack;
+	BOOL humanReadable;
+	BOOL sortKeys;
+	id<SBJsonStreamWriterDelegate> delegate;
 }
 
 @property (nonatomic, assign) SBJsonStreamWriterState *state; // Internal

--- a/Classes/SBJsonStreamWriterAccumulator.h
+++ b/Classes/SBJsonStreamWriterAccumulator.h
@@ -29,7 +29,9 @@
 
 #import "SBJsonStreamWriter.h"
 
-@interface SBJsonStreamWriterAccumulator : NSObject <SBJsonStreamWriterDelegate>
+@interface SBJsonStreamWriterAccumulator : NSObject <SBJsonStreamWriterDelegate> {
+	NSMutableData* data;
+}
 
 @property (readonly, copy) NSMutableData* data;
 

--- a/Classes/SBJsonTokeniser.h
+++ b/Classes/SBJsonTokeniser.h
@@ -55,7 +55,10 @@ typedef enum {
 
 @class SBJsonUTF8Stream;
 
-@interface SBJsonTokeniser : NSObject 
+@interface SBJsonTokeniser : NSObject {
+	NSString *_error;
+	SBJsonUTF8Stream *_stream;
+}
 
 @property (retain) SBJsonUTF8Stream *stream;
 @property (copy) NSString *error;

--- a/Classes/SBJsonUTF8Stream.h
+++ b/Classes/SBJsonUTF8Stream.h
@@ -37,6 +37,7 @@
     const char *_bytes;
     NSMutableData *_data;
     NSUInteger _length;
+	NSUInteger _index;
 }
 
 @property (assign) NSUInteger index;

--- a/Classes/SBJsonWriter.h
+++ b/Classes/SBJsonWriter.h
@@ -37,7 +37,12 @@
  @see @ref json2objc
  */
 
-@interface SBJsonWriter : NSObject
+@interface SBJsonWriter : NSObject {
+	BOOL sortKeys;
+	BOOL humanReadable;
+	NSString *error;
+	NSUInteger maxDepth;
+}
 
 /**
  @brief The maximum recursing depth.

--- a/SBJson.xcodeproj/project.pbxproj
+++ b/SBJson.xcodeproj/project.pbxproj
@@ -694,6 +694,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -709,6 +710,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -716,7 +718,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 33;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -738,7 +739,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 33;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";


### PR DESCRIPTION
I’ve made a few changes to make SBJson.framework compatible with 32-bit targets and Xcode 4's archiving feature.

I’ve enabled the `SKIP_INSTALL` build setting at the project level. This will prevent
products from the SBJson project from being included in archives
created for products from projects depending on them.

I’ve also added explicit ivars to the following classes so they are compatible
with the 32-bit runtime on OS X (which doesn't support synthesized ivars):
- `SBJsonParser`
- `SBJsonStreamParser`
- `SBJsonStreamParserAccumulator`
- `SBJsonStreamWriter`
- `SBJsonStreamWriterAccumulator`
- `SBJsonTokeniser`
- `SBJsonUTF8Stream`
- `SBJsonWriter`
