### PR TITLE
Fixed compiler errors with latest LLVM

### DIFF
--- a/Classes/SBJsonUTF8Stream.m
+++ b/Classes/SBJsonUTF8Stream.m
@@ -62,7 +62,7 @@
     [_data appendData:data_];
     
     // This is an optimisation. 
-    _bytes = [_data bytes];
+    _bytes = (const char*)[_data bytes];
     _length = [_data length];
 }
 
@@ -126,7 +126,7 @@
 }
 
 - (BOOL)skipCharacters:(const char *)chars length:(NSUInteger)len {
-    const void *bytes = [_data bytes] + _index;
+    const void *bytes = ((const char*)[_data bytes]) + _index;
     if (!memcmp(bytes, chars, len)) {
         _index += len;
         return YES;


### PR DESCRIPTION
Some compiler errors/warnings having to do with pointer math on void\* fixed. Should be backwards compatible.
