### PR TITLE
Make SINGLETON thread safe

### DIFF
--- a/Classes/SBJsonStreamParserState.m
+++ b/Classes/SBJsonStreamParserState.m
@@ -36,8 +36,11 @@
 #define SINGLETON \
 + (id)sharedInstance { \
     static id state = nil; \
-    static dispatch_once_t once = 0; \
-    dispatch_once(&once, ^{state = [[self alloc] init];}); \
+    if (!state) { \
+        @synchronized(self) { \
+            if (!state) state = [[self alloc] init]; \
+        } \
+    } \
     return state; \
 }
 

--- a/Classes/SBJsonStreamWriterState.m
+++ b/Classes/SBJsonStreamWriterState.m
@@ -36,8 +36,11 @@
 #define SINGLETON \
 + (id)sharedInstance { \
     static id state = nil; \
-    static dispatch_once_t once = 0; \
-    dispatch_once(&once, ^{state = [[self alloc] init];}); \
+    if (!state) { \
+        @synchronized(self) { \
+            if (!state) state = [[self alloc] init]; \
+        } \
+    } \
     return state; \
 }
 


### PR DESCRIPTION
Original SINGLETON in SBJsonStreamParserState.m & SBJsonStreamWriterState.m is not thread safe, when we use SBJSON concurrently, our app sometimes crashed while sending message to state, because state is dealloced.
