### PR TITLE
Fix: missing #import Foundation.h in SBJsonStreamTokeniser.h

### DIFF
--- a/src/main/objc/SBJsonStreamTokeniser.h
+++ b/src/main/objc/SBJsonStreamTokeniser.h
@@ -4,7 +4,7 @@
 // To change the template use AppCode | Preferences | File Templates.
 //
 
-
+#import <Foundation/Foundation.h>
 
 typedef enum {
     sbjson_token_error = -1,


### PR DESCRIPTION
Caused error: cannot find interface declaration for 'NSObject', superclass of 'SBJsonStreamTokeniser'
