### PR TITLE
Add @rpath support to SBJson.framework build settings

### DIFF
--- a/SBJson.xcodeproj/project.pbxproj
+++ b/SBJson.xcodeproj/project.pbxproj
@@ -746,6 +746,7 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "SBJson/SBJson-Prefix.pch";
 				INFOPLIST_FILE = "SBJson/SBJson-Info.plist";
+				INSTALL_PATH = "@rpath";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = framework;
@@ -765,6 +766,7 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "SBJson/SBJson-Prefix.pch";
 				INFOPLIST_FILE = "SBJson/SBJson-Info.plist";
+				INSTALL_PATH = "@rpath";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = framework;


### PR DESCRIPTION
@rpath facilitates framework embedding in OSX applications:
1. Add 'SBJson.xcodeproj' as a subproject of **your** project
2. Go to **your** application target Build Settings and set 'Runpath Search Path' to `@loader_path/../Frameworks`
3. Add SBJson framework as a target dependency in application target Build Phases
4. Link SBJson framework in application target Build Phases
5. Copy SBJson framework to 'Frameworks' directory in application target Build Phases

NOTE: Should work the same with Xcode workspaces.
