### PR TITLE
Return NULL for invalid chars

### DIFF
--- a/src/main/objc/SBJson4StreamWriter.m
+++ b/src/main/objc/SBJson4StreamWriter.m
@@ -268,6 +268,7 @@ static const char *strForChar(int c) {
 		case 92: return "\\\\";
 		default:
 			[NSException raise:@"Illegal escape char" format:@"-->%c<-- is not a legal escape character", c];
+			return NULL;
 	}
 }
 


### PR DESCRIPTION
This point will never be reached, thanks to throwing an exception, but
a return value is needed to shut the compiler up
