### PR TITLE
Use Xcodebuild rather than xctool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 xcode_project: SBJson.xcodeproj
 env:
-  - SCHEME="-sdk iphonesimulator -scheme sbjson-ios"
-  - SCHEME="-scheme SBJson"
-script: "xctool $SCHEME test"
+  - SCHEME="sbjson-ios"
+  - SCHEME="SBJson"
+script: "xcodebuild -scheme $SCHEME test"


### PR DESCRIPTION
As xctool doesn't support running tests on iphone simulator without
weird hacks, but xcodebuild appears to do.

Thanks to @robb for inspiration for this.