### PR TITLE
First (failed) attempt at using the buck build tool

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,51 @@
+[cache]
+  mode = dir
+
+[cxx]
+  default_platform = iphonesimulator-x86_64
+  cflags = -g -std=c11
+  cxxflags = -g -std=c++14
+  combined_preprocess_and_compile = true
+
+[alias]
+  sbjson_ios = //ios:SBJson-iOS
+  sbjson_mac = //mac:SBJson-iOS
+
+[project]
+  ide = xcode
+  ignore = .buckd, \
+           .hg, \
+           .git, \
+           buck-cache, \
+           buck-out, \
+
+apple_library(
+  name = 'SBJson-iOS',
+  deps = [],
+  preprocessor_flags = ['-fobjc-arc'],
+  header_path_prefix = 'SBJson',
+  exported_headers = [
+    'src/main/objc/SBJson4.h',
+  ],
+  headers = [
+    'src/main/objc/SBJson4Parser.h',
+    'src/main/objc/SBJson4StreamParser.h',
+    'src/main/objc/SBJson4StreamParserState.h',
+    'src/main/objc/SBJson4StreamTokeniser.h',
+    'src/main/objc/SBJson4StreamWriter.h',
+    'src/main/objc/SBJson4StreamWriterState.h',
+    'src/main/objc/SBJson4Writer.h',
+  ],
+  srcs = [
+    'src/main/objc/SBJson4Parser.m',
+    'src/main/objc/SBJson4StreamParser.m',
+    'src/main/objc/SBJson4StreamParserState.m',
+    'src/main/objc/SBJson4StreamTokeniser.m',
+    'src/main/objc/SBJson4StreamWriter.m',
+    'src/main/objc/SBJson4StreamWriterState.m',
+    'src/main/objc/SBJson4Writer.m',
+  ],
+  frameworks = [
+    '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+  ],
+)

--- a/.buckconfig
+++ b/.buckconfig
@@ -26,15 +26,15 @@ apple_library(
   header_path_prefix = 'SBJson',
   exported_headers = [
     'src/main/objc/SBJson4.h',
-  ],
-  headers = [
     'src/main/objc/SBJson4Parser.h',
+    'src/main/objc/SBJson4Writer.h',
     'src/main/objc/SBJson4StreamParser.h',
-    'src/main/objc/SBJson4StreamParserState.h',
     'src/main/objc/SBJson4StreamTokeniser.h',
     'src/main/objc/SBJson4StreamWriter.h',
+  ],
+  headers = [
+    'src/main/objc/SBJson4StreamParserState.h',
     'src/main/objc/SBJson4StreamWriterState.h',
-    'src/main/objc/SBJson4Writer.h',
   ],
   srcs = [
     'src/main/objc/SBJson4Parser.m',

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ profile
 DerivedData
 .idea/
 .DS_Store
+
+# Buck
+/buck-out
+/buck-cache
+/.buckconfig.local
+/.buckd


### PR DESCRIPTION
... because I would _love_ to lose the Xcode config file. However, issuing `buck build sbjson_ios` from the top-level directory results in:

```shell
$ buck build sbjson_ios    
Using buckd.
[2015-09-30 22:30:56.192][error][command:45b245b8-020b-44a9-86d9-02d04f8526e3][tid:33][com.facebook.buck.cli.Main] Uncaught exception at top level
org.ini4j.InvalidFileFormatException: parse error (at line: 28): 'src/main/objc/SBJson4.h',
	at org.ini4j.spi.AbstractParser.parseError(AbstractParser.java:53)
	at org.ini4j.spi.AbstractParser.parseOptionLine(AbstractParser.java:85)
	at org.ini4j.spi.IniParser.parse(IniParser.java:101)
	at org.ini4j.spi.IniParser.parse(IniParser.java:62)
	at org.ini4j.Ini.load(Ini.java:109)
	at com.facebook.buck.cli.Inis.read(Inis.java:35)
	at com.facebook.buck.cli.Config.createDefaultConfig(Config.java:108)
	at com.facebook.buck.cli.Main.runMainWithExitCode(Main.java:513)
	at com.facebook.buck.cli.Main.tryRunMainWithExitCode(Main.java:1159)
	at com.facebook.buck.cli.Main.runMainThenExit(Main.java:1216)
	at com.facebook.buck.cli.Main.nailMain(Main.java:1245)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.martiansoftware.nailgun.NGSession.run(NGSession.java:331)

```