### PR TITLE
Add dynamic framework target (Carthage)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 xcode_project: SBJson.xcodeproj
 env:
   - SCHEME="sbjson-ios"
-  - SCHEME="SBJson"
+  - SCHEME="SBJson4-Mac"
 script:
   - xcodebuild -scheme $SCHEME test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
 after_success:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ implements chunk-based JSON parsing and generation in Objective-C.
 
 [![Project Status: Inactive - The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](http://www.repostatus.org/badges/0.1.0/inactive.svg)](http://www.repostatus.org/#inactive)
 
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
 Features
 --------
 
@@ -39,6 +41,7 @@ more details.
 Installation
 ------------
 
+### CocoaPods
 The preferred way to use SBJson is by using
 [CocoaPods](http://cocoapods.org/?q=sbjson). In your Podfile use:
 
@@ -50,8 +53,13 @@ transition---you can instead use:
 
     pod 'SBJson4', '~> 4.0.1'
 
-An alternative that I no longer recommend is to copy all the source files (the
-contents of the `src/main/objc` folder) into your own Xcode project.
+### Carthage
+SBJson is compatible with _Carthage_. Follow the [Getting Started Guide for iOS](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
+
+	github "stig/json-framework" == 4.0.3
+
+### Copy source files
+An alternative that I no longer recommend is to copy all the source files (the contents of the `src/main/objc` folder) into your own Xcode project.
 
 Examples
 --------

--- a/SBJson.xcodeproj/project.pbxproj
+++ b/SBJson.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BC12324B1391D5CC00131607 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BC1232491391D5CC00131607 /* InfoPlist.strings */; };
-		BC1232561391D5CC00131607 /* SBJson.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC12323D1391D5CC00131607 /* SBJson.framework */; };
+		BC1232561391D5CC00131607 /* SBJson4.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC12323D1391D5CC00131607 /* SBJson4.framework */; };
 		BC12325C1391D5CC00131607 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BC12325A1391D5CC00131607 /* InfoPlist.strings */; };
 		BC417FF413A1008F00C8BC49 /* ErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88522B1391D6DD00370E55 /* ErrorTest.m */; };
 		BC417FF613A1008F00C8BC49 /* JsonCheckerSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88522D1391D6DD00370E55 /* JsonCheckerSuite.m */; };
@@ -46,8 +46,6 @@
 		BCC2629313921035003D9994 /* SBJson4StreamWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851331391D6CD00370E55 /* SBJson4StreamWriter.m */; };
 		BCC2629513921035003D9994 /* SBJson4StreamWriterState.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851371391D6CD00370E55 /* SBJson4StreamWriterState.m */; };
 		BCC2629713921035003D9994 /* SBJson4Writer.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88513B1391D6CD00370E55 /* SBJson4Writer.m */; };
-		D762B23918FB3DA700470E1A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D762B23818FB3DA700470E1A /* XCTest.framework */; };
-		D762B23A18FB3DAF00470E1A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D762B23818FB3DA700470E1A /* XCTest.framework */; };
 		D7F64E60169262AE009DF12E /* jsonchecker in Resources */ = {isa = PBXBuildFile; fileRef = D7F64E5F169262AE009DF12E /* jsonchecker */; };
 		D7F64E61169262AE009DF12E /* jsonchecker in Resources */ = {isa = PBXBuildFile; fileRef = D7F64E5F169262AE009DF12E /* jsonchecker */; };
 		D7F64E661692697D009DF12E /* stream in Resources */ = {isa = PBXBuildFile; fileRef = D7F64E651692697D009DF12E /* stream */; };
@@ -103,7 +101,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		BC12323D1391D5CC00131607 /* SBJson.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SBJson.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC12323D1391D5CC00131607 /* SBJson4.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SBJson4.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC1232481391D5CC00131607 /* SBJson-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SBJson-Info.plist"; sourceTree = "<group>"; };
 		BC12324A1391D5CC00131607 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BC1232521391D5CC00131607 /* SBJsonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SBJsonTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,7 +130,6 @@
 		BCC2627E13920FC7003D9994 /* sbjson-iosTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "sbjson-iosTests-Info.plist"; sourceTree = "<group>"; };
 		BCC2628013920FC7003D9994 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BCC2628213920FC7003D9994 /* sbjson-iosTests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "sbjson-iosTests-Prefix.pch"; sourceTree = "<group>"; };
-		D762B23818FB3DA700470E1A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		D7F64E5F169262AE009DF12E /* jsonchecker */ = {isa = PBXFileReference; lastKnownFileType = folder; path = jsonchecker; sourceTree = "<group>"; };
 		D7F64E651692697D009DF12E /* stream */ = {isa = PBXFileReference; lastKnownFileType = folder; path = stream; sourceTree = "<group>"; };
 		D7F64E7C1692D24D009DF12E /* main */ = {isa = PBXFileReference; lastKnownFileType = folder; path = main; sourceTree = "<group>"; };
@@ -158,8 +155,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D762B23A18FB3DAF00470E1A /* XCTest.framework in Frameworks */,
-				BC1232561391D5CC00131607 /* SBJson.framework in Frameworks */,
+				BC1232561391D5CC00131607 /* SBJson4.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -174,7 +170,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D762B23918FB3DA700470E1A /* XCTest.framework in Frameworks */,
 				BCC2627B13920FC7003D9994 /* libsbjson-ios.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -192,7 +187,6 @@
 		BC1232311391D5CC00131607 = {
 			isa = PBXGroup;
 			children = (
-				D762B23818FB3DA700470E1A /* XCTest.framework */,
 				D7F64E201692549E009DF12E /* src */,
 				BC1232461391D5CC00131607 /* SBJson */,
 				BC1232571391D5CC00131607 /* SBJsonTests */,
@@ -204,7 +198,7 @@
 		BC12323E1391D5CC00131607 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				BC12323D1391D5CC00131607 /* SBJson.framework */,
+				BC12323D1391D5CC00131607 /* SBJson4.framework */,
 				BC1232521391D5CC00131607 /* SBJsonTests.xctest */,
 				BCC2626913920FC7003D9994 /* libsbjson-ios.a */,
 				BCC2627313920FC7003D9994 /* sbjson-iosTests.xctest */,
@@ -391,9 +385,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		BC12323C1391D5CC00131607 /* SBJson */ = {
+		BC12323C1391D5CC00131607 /* SBJson4-Mac */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BC1232641391D5CC00131607 /* Build configuration list for PBXNativeTarget "SBJson" */;
+			buildConfigurationList = BC1232641391D5CC00131607 /* Build configuration list for PBXNativeTarget "SBJson4-Mac" */;
 			buildPhases = (
 				BC1232381391D5CC00131607 /* Sources */,
 				BC1232391391D5CC00131607 /* Frameworks */,
@@ -404,9 +398,9 @@
 			);
 			dependencies = (
 			);
-			name = SBJson;
+			name = "SBJson4-Mac";
 			productName = SBJson;
-			productReference = BC12323D1391D5CC00131607 /* SBJson.framework */;
+			productReference = BC12323D1391D5CC00131607 /* SBJson4.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		BC1232511391D5CC00131607 /* SBJsonTests */ = {
@@ -506,7 +500,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				BC12323C1391D5CC00131607 /* SBJson */,
+				BC12323C1391D5CC00131607 /* SBJson4-Mac */,
 				D9B035321D269C1D00F3EDA9 /* SBJson4-iOS */,
 				BC1232511391D5CC00131607 /* SBJsonTests */,
 				BCC2626813920FC7003D9994 /* sbjson-ios */,
@@ -635,7 +629,7 @@
 /* Begin PBXTargetDependency section */
 		BC1232551391D5CC00131607 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = BC12323C1391D5CC00131607 /* SBJson */;
+			target = BC12323C1391D5CC00131607 /* SBJson4-Mac */;
 			targetProxy = BC1232541391D5CC00131607 /* PBXContainerItemProxy */;
 		};
 		BCC2627A13920FC7003D9994 /* PBXTargetDependency */ = {
@@ -714,9 +708,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 39;
 				FRAMEWORK_VERSION = A;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = "SBJson/SBJson-Info.plist";
 				INSTALL_PATH = "@rpath";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.brautaset.SBJson4;
+				PRODUCT_NAME = SBJson4;
 				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -735,7 +731,8 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "SBJson/SBJson-Info.plist";
 				INSTALL_PATH = "@rpath";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.brautaset.SBJson4;
+				PRODUCT_NAME = SBJson4;
 				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -882,7 +879,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.brautaset.SBJson4-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = org.brautaset.SBJson4;
 				PRODUCT_NAME = SBJson4;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -932,7 +929,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.brautaset.SBJson4-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = org.brautaset.SBJson4;
 				PRODUCT_NAME = SBJson4;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -955,7 +952,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BC1232641391D5CC00131607 /* Build configuration list for PBXNativeTarget "SBJson" */ = {
+		BC1232641391D5CC00131607 /* Build configuration list for PBXNativeTarget "SBJson4-Mac" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BC1232651391D5CC00131607 /* Debug */,
@@ -998,6 +995,7 @@
 				D9B035391D269C1D00F3EDA9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SBJson.xcodeproj/project.pbxproj
+++ b/SBJson.xcodeproj/project.pbxproj
@@ -58,6 +58,21 @@
 		D7F64EBA1696C3F8009DF12E /* comparatorsort in Resources */ = {isa = PBXBuildFile; fileRef = D7F64EB71696C3F8009DF12E /* comparatorsort */; };
 		D7F64EBB1696C3F8009DF12E /* format in Resources */ = {isa = PBXBuildFile; fileRef = D7F64EB81696C3F8009DF12E /* format */; };
 		D7F64EBC1696C3F8009DF12E /* format in Resources */ = {isa = PBXBuildFile; fileRef = D7F64EB81696C3F8009DF12E /* format */; };
+		D9B0353B1D269CE400F3EDA9 /* SBJson4.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8851271391D6CD00370E55 /* SBJson4.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B0353C1D269CE400F3EDA9 /* SBJson4StreamWriterState.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8851361391D6CD00370E55 /* SBJson4StreamWriterState.h */; };
+		D9B0353D1D269CE400F3EDA9 /* SBJson4StreamParserState.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8851301391D6CD00370E55 /* SBJson4StreamParserState.h */; };
+		D9B0353E1D269CE400F3EDA9 /* SBJson4StreamWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8851321391D6CD00370E55 /* SBJson4StreamWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B0353F1D269CE400F3EDA9 /* SBJson4StreamParser.h in Headers */ = {isa = PBXBuildFile; fileRef = BC88512A1391D6CD00370E55 /* SBJson4StreamParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B035401D269CE400F3EDA9 /* SBJson4Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = BC88512E1391D6CD00370E55 /* SBJson4Parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B035411D269CE400F3EDA9 /* SBJson4Writer.h in Headers */ = {isa = PBXBuildFile; fileRef = BC88513A1391D6CD00370E55 /* SBJson4Writer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B035421D269CE400F3EDA9 /* SBJson4StreamTokeniser.h in Headers */ = {isa = PBXBuildFile; fileRef = F8D041B0DB689CC78ABDF64D /* SBJson4StreamTokeniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9B035431D269CF800F3EDA9 /* SBJson4StreamWriterState.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851371391D6CD00370E55 /* SBJson4StreamWriterState.m */; };
+		D9B035441D269CF800F3EDA9 /* SBJson4StreamWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851331391D6CD00370E55 /* SBJson4StreamWriter.m */; };
+		D9B035451D269CF800F3EDA9 /* SBJson4StreamParser.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88512B1391D6CD00370E55 /* SBJson4StreamParser.m */; };
+		D9B035461D269CF800F3EDA9 /* SBJson4Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88512F1391D6CD00370E55 /* SBJson4Parser.m */; };
+		D9B035471D269CF800F3EDA9 /* SBJson4Writer.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88513B1391D6CD00370E55 /* SBJson4Writer.m */; };
+		D9B035481D269CF800F3EDA9 /* SBJson4StreamParserState.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851311391D6CD00370E55 /* SBJson4StreamParserState.m */; };
+		D9B035491D269CF800F3EDA9 /* SBJson4StreamTokeniser.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D04518FD72EFA646581EAB /* SBJson4StreamTokeniser.m */; };
 		F8D04131C6B0E02EC6FB1D39 /* SBJson4StreamTokeniser.h in Headers */ = {isa = PBXBuildFile; fileRef = F8D041B0DB689CC78ABDF64D /* SBJson4StreamTokeniser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F8D0414D5B6D665D141013D1 /* kuhn in Resources */ = {isa = PBXBuildFile; fileRef = F8D04F2055A30B07D7E8AEAF /* kuhn */; };
 		F8D0434D37D8894CD87E4982 /* SBJson4StreamTokeniser.m in Sources */ = {isa = PBXBuildFile; fileRef = F8D04518FD72EFA646581EAB /* SBJson4StreamTokeniser.m */; };
@@ -123,6 +138,7 @@
 		D7F64E7C1692D24D009DF12E /* main */ = {isa = PBXFileReference; lastKnownFileType = folder; path = main; sourceTree = "<group>"; };
 		D7F64EB71696C3F8009DF12E /* comparatorsort */ = {isa = PBXFileReference; lastKnownFileType = folder; path = comparatorsort; sourceTree = "<group>"; };
 		D7F64EB81696C3F8009DF12E /* format */ = {isa = PBXFileReference; lastKnownFileType = folder; path = format; sourceTree = "<group>"; };
+		D9B035331D269C1D00F3EDA9 /* SBJson4.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SBJson4.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8D041B0DB689CC78ABDF64D /* SBJson4StreamTokeniser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBJson4StreamTokeniser.h; sourceTree = "<group>"; };
 		F8D04518FD72EFA646581EAB /* SBJson4StreamTokeniser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBJson4StreamTokeniser.m; sourceTree = "<group>"; };
 		F8D04A94F7A4284E41E96B8F /* MainSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MainSuite.m; sourceTree = "<group>"; };
@@ -163,6 +179,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D9B0352F1D269C1D00F3EDA9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -185,6 +208,7 @@
 				BC1232521391D5CC00131607 /* SBJsonTests.xctest */,
 				BCC2626913920FC7003D9994 /* libsbjson-ios.a */,
 				BCC2627313920FC7003D9994 /* sbjson-iosTests.xctest */,
+				D9B035331D269C1D00F3EDA9 /* SBJson4.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -349,6 +373,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D9B035301D269C1D00F3EDA9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9B0353B1D269CE400F3EDA9 /* SBJson4.h in Headers */,
+				D9B0353E1D269CE400F3EDA9 /* SBJson4StreamWriter.h in Headers */,
+				D9B0353F1D269CE400F3EDA9 /* SBJson4StreamParser.h in Headers */,
+				D9B035401D269CE400F3EDA9 /* SBJson4Parser.h in Headers */,
+				D9B035411D269CE400F3EDA9 /* SBJson4Writer.h in Headers */,
+				D9B035421D269CE400F3EDA9 /* SBJson4StreamTokeniser.h in Headers */,
+				D9B0353C1D269CE400F3EDA9 /* SBJson4StreamWriterState.h in Headers */,
+				D9B0353D1D269CE400F3EDA9 /* SBJson4StreamParserState.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -423,6 +462,24 @@
 			productReference = BCC2627313920FC7003D9994 /* sbjson-iosTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D9B035321D269C1D00F3EDA9 /* SBJson4-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D9B0353A1D269C1D00F3EDA9 /* Build configuration list for PBXNativeTarget "SBJson4-iOS" */;
+			buildPhases = (
+				D9B0352E1D269C1D00F3EDA9 /* Sources */,
+				D9B0352F1D269C1D00F3EDA9 /* Frameworks */,
+				D9B035301D269C1D00F3EDA9 /* Headers */,
+				D9B035311D269C1D00F3EDA9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SBJson4-iOS";
+			productName = "SBJson4-iOS";
+			productReference = D9B035331D269C1D00F3EDA9 /* SBJson4.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -431,6 +488,11 @@
 			attributes = {
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Stig Brautaset";
+				TargetAttributes = {
+					D9B035321D269C1D00F3EDA9 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
 			};
 			buildConfigurationList = BC1232361391D5CC00131607 /* Build configuration list for PBXProject "SBJson" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -445,6 +507,7 @@
 			projectRoot = "";
 			targets = (
 				BC12323C1391D5CC00131607 /* SBJson */,
+				D9B035321D269C1D00F3EDA9 /* SBJson4-iOS */,
 				BC1232511391D5CC00131607 /* SBJsonTests */,
 				BCC2626813920FC7003D9994 /* sbjson-ios */,
 				BCC2627213920FC7003D9994 /* sbjson-iosTests */,
@@ -486,6 +549,13 @@
 				D7F64EBA1696C3F8009DF12E /* comparatorsort in Resources */,
 				D7F64EBC1696C3F8009DF12E /* format in Resources */,
 				F8D0414D5B6D665D141013D1 /* kuhn in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D9B035311D269C1D00F3EDA9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -543,6 +613,20 @@
 				BC417FFB13A1008F00C8BC49 /* StreamSuite.m in Sources */,
 				F8D0486A2C9EF8BAACFBD35D /* MainSuite.m in Sources */,
 				F8D048869423310097A4889E /* JsonStreamTokeniserTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D9B0352E1D269C1D00F3EDA9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9B035431D269CF800F3EDA9 /* SBJson4StreamWriterState.m in Sources */,
+				D9B035441D269CF800F3EDA9 /* SBJson4StreamWriter.m in Sources */,
+				D9B035451D269CF800F3EDA9 /* SBJson4StreamParser.m in Sources */,
+				D9B035461D269CF800F3EDA9 /* SBJson4Parser.m in Sources */,
+				D9B035471D269CF800F3EDA9 /* SBJson4Writer.m in Sources */,
+				D9B035481D269CF800F3EDA9 /* SBJson4StreamParserState.m in Sources */,
+				D9B035491D269CF800F3EDA9 /* SBJson4StreamTokeniser.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -752,6 +836,113 @@
 			};
 			name = Release;
 		};
+		D9B035381D269C1D00F3EDA9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SBJson/SBJson-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.brautaset.SBJson4-iOS";
+				PRODUCT_NAME = SBJson4;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D9B035391D269C1D00F3EDA9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SBJson/SBJson-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.brautaset.SBJson4-iOS";
+				PRODUCT_NAME = SBJson4;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -799,6 +990,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		D9B0353A1D269C1D00F3EDA9 /* Build configuration list for PBXNativeTarget "SBJson4-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D9B035381D269C1D00F3EDA9 /* Debug */,
+				D9B035391D269C1D00F3EDA9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SBJson.xcodeproj/project.pbxproj
+++ b/SBJson.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		BCC2629313921035003D9994 /* SBJson4StreamWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851331391D6CD00370E55 /* SBJson4StreamWriter.m */; };
 		BCC2629513921035003D9994 /* SBJson4StreamWriterState.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8851371391D6CD00370E55 /* SBJson4StreamWriterState.m */; };
 		BCC2629713921035003D9994 /* SBJson4Writer.m in Sources */ = {isa = PBXBuildFile; fileRef = BC88513B1391D6CD00370E55 /* SBJson4Writer.m */; };
+		D762B23918FB3DA700470E1A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D762B23818FB3DA700470E1A /* XCTest.framework */; };
+		D762B23A18FB3DAF00470E1A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D762B23818FB3DA700470E1A /* XCTest.framework */; };
 		D7F64E60169262AE009DF12E /* jsonchecker in Resources */ = {isa = PBXBuildFile; fileRef = D7F64E5F169262AE009DF12E /* jsonchecker */; };
 		D7F64E61169262AE009DF12E /* jsonchecker in Resources */ = {isa = PBXBuildFile; fileRef = D7F64E5F169262AE009DF12E /* jsonchecker */; };
 		D7F64E661692697D009DF12E /* stream in Resources */ = {isa = PBXBuildFile; fileRef = D7F64E651692697D009DF12E /* stream */; };
@@ -130,6 +132,7 @@
 		BCC2627E13920FC7003D9994 /* sbjson-iosTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "sbjson-iosTests-Info.plist"; sourceTree = "<group>"; };
 		BCC2628013920FC7003D9994 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		BCC2628213920FC7003D9994 /* sbjson-iosTests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "sbjson-iosTests-Prefix.pch"; sourceTree = "<group>"; };
+		D762B23818FB3DA700470E1A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		D7F64E5F169262AE009DF12E /* jsonchecker */ = {isa = PBXFileReference; lastKnownFileType = folder; path = jsonchecker; sourceTree = "<group>"; };
 		D7F64E651692697D009DF12E /* stream */ = {isa = PBXFileReference; lastKnownFileType = folder; path = stream; sourceTree = "<group>"; };
 		D7F64E7C1692D24D009DF12E /* main */ = {isa = PBXFileReference; lastKnownFileType = folder; path = main; sourceTree = "<group>"; };
@@ -155,6 +158,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D762B23A18FB3DAF00470E1A /* XCTest.framework in Frameworks */,
 				BC1232561391D5CC00131607 /* SBJson4.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -170,6 +174,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D762B23918FB3DA700470E1A /* XCTest.framework in Frameworks */,
 				BCC2627B13920FC7003D9994 /* libsbjson-ios.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -187,6 +192,7 @@
 		BC1232311391D5CC00131607 = {
 			isa = PBXGroup;
 			children = (
+				D762B23818FB3DA700470E1A /* XCTest.framework */,
 				D7F64E201692549E009DF12E /* src */,
 				BC1232461391D5CC00131607 /* SBJson */,
 				BC1232571391D5CC00131607 /* SBJsonTests */,

--- a/SBJson.xcodeproj/xcshareddata/xcschemes/SBJson4-Mac.xcscheme
+++ b/SBJson.xcodeproj/xcshareddata/xcschemes/SBJson4-Mac.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BC12323C1391D5CC00131607"
-               BuildableName = "SBJson.framework"
-               BlueprintName = "SBJson"
+               BuildableName = "SBJson4.framework"
+               BlueprintName = "SBJson4-Mac"
                ReferencedContainer = "container:SBJson.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -37,10 +37,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,24 +54,36 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BC12323C1391D5CC00131607"
+            BuildableName = "SBJson4.framework"
+            BlueprintName = "SBJson4-Mac"
+            ReferencedContainer = "container:SBJson.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/SBJson.xcodeproj/xcshareddata/xcschemes/SBJson4-iOS.xcscheme
+++ b/SBJson.xcodeproj/xcshareddata/xcschemes/SBJson4-iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D9B035321D269C1D00F3EDA9"
+               BuildableName = "SBJson4-iOS.framework"
+               BlueprintName = "SBJson4-iOS"
+               ReferencedContainer = "container:SBJson.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D9B035321D269C1D00F3EDA9"
+            BuildableName = "SBJson4-iOS.framework"
+            BlueprintName = "SBJson4-iOS"
+            ReferencedContainer = "container:SBJson.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D9B035321D269C1D00F3EDA9"
+            BuildableName = "SBJson4-iOS.framework"
+            BlueprintName = "SBJson4-iOS"
+            ReferencedContainer = "container:SBJson.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SBJson.xcodeproj/xcshareddata/xcschemes/SBJson4-iOS.xcscheme
+++ b/SBJson.xcodeproj/xcshareddata/xcschemes/SBJson4-iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D9B035321D269C1D00F3EDA9"
-               BuildableName = "SBJson4-iOS.framework"
+               BuildableName = "SBJson4.framework"
                BlueprintName = "SBJson4-iOS"
                ReferencedContainer = "container:SBJson.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D9B035321D269C1D00F3EDA9"
-            BuildableName = "SBJson4-iOS.framework"
+            BuildableName = "SBJson4.framework"
             BlueprintName = "SBJson4-iOS"
             ReferencedContainer = "container:SBJson.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D9B035321D269C1D00F3EDA9"
-            BuildableName = "SBJson4-iOS.framework"
+            BuildableName = "SBJson4.framework"
             BlueprintName = "SBJson4-iOS"
             ReferencedContainer = "container:SBJson.xcodeproj">
          </BuildableReference>

--- a/SBJson/SBJson-Info.plist
+++ b/SBJson/SBJson-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.2</string>
+	<string>4.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR adds a [Carthage](https://github.com/Carthage/Carthage) compatible dynamic framework target #203.
The resulting artifact is `SBJson4.framework`.

In order to have consistent targets, I've renamed the Mac target to *SBJson4-Mac*.

@stig please review and tag the release `v4.0.3`