### PR TITLE
Remove untested processBlock: functionality

### DIFF
--- a/Classes/SBJson5Parser.h
+++ b/Classes/SBJson5Parser.h
@@ -48,14 +48,6 @@ typedef void (^SBJson5ValueBlock)(id item, BOOL* stop);
  */
 typedef void (^SBJson5ErrorBlock)(NSError* error);
 
-/**
- Block used to process parsed tokens as they are encountered. You can use this
- to transform strings containing dates into NSDate, for example.
- @param item the parsed token
- @param path the JSON Path of the token
- */
-typedef id (^SBJson5ProcessBlock)(id item, NSString* path);
-
 
 /**
  Parse one or more chunks of JSON data.
@@ -160,7 +152,7 @@ typedef id (^SBJson5ProcessBlock)(id item, NSString* path);
 
  @see -unwrapRootArrayParserWithBlock:errorHandler:
  @see -multiRootParserWithBlock:errorHandler:
- @see -initWithBlock:processBlock:multiRoot:unwrapRootArray:maxDepth:errorHandler:
+ @see -initWithBlock:multiRoot:unwrapRootArray:maxDepth:errorHandler:
 
  */
 + (id)parserWithBlock:(SBJson5ValueBlock)block
@@ -181,7 +173,7 @@ typedef id (^SBJson5ProcessBlock)(id item, NSString* path);
 
  @see +unwrapRootArrayParserWithBlock:errorHandler:
  @see +parserWithBlock:allowMultiRoot:unwrapRootArray:errorHandler:
- @see -initWithBlock:processBlock:multiRoot:unwrapRootArray:maxDepth:errorHandler:
+ @see -initWithBlock:multiRoot:unwrapRootArray:maxDepth:errorHandler:
  */
 + (id)multiRootParserWithBlock:(SBJson5ValueBlock)block
                   errorHandler:(SBJson5ErrorBlock)eh;
@@ -197,7 +189,7 @@ typedef id (^SBJson5ProcessBlock)(id item, NSString* path);
 
  @see +multiRootParserWithBlock:errorHandler:
  @see +parserWithBlock:allowMultiRoot:unwrapRootArray:errorHandler:
- @see -initWithBlock:processBlock:multiRoot:unwrapRootArray:maxDepth:errorHandler:
+ @see -initWithBlock:multiRoot:unwrapRootArray:maxDepth:errorHandler:
  */
 + (id)unwrapRootArrayParserWithBlock:(SBJson5ValueBlock)block
                         errorHandler:(SBJson5ErrorBlock)eh;
@@ -207,9 +199,6 @@ typedef id (^SBJson5ProcessBlock)(id item, NSString* path);
 
  @param block Called for each element. Set *stop to `YES` if you have seen
  enough and would like to skip the rest of the elements.
-
- @param processBlock A block that allows you to process individual values before being
- returned.
 
  @param multiRoot Indicate that you are expecting multiple whitespace-separated
  JSON documents, similar to what Twitter uses.
@@ -224,7 +213,6 @@ typedef id (^SBJson5ProcessBlock)(id item, NSString* path);
 
  */
 - (id)initWithBlock:(SBJson5ValueBlock)block
-       processBlock:(SBJson5ProcessBlock)processBlock
           multiRoot:(BOOL)multiRoot
     unwrapRootArray:(BOOL)unwrapRootArray
            maxDepth:(NSUInteger)maxDepth

--- a/Tests/JsonCheckerSuite.m
+++ b/Tests/JsonCheckerSuite.m
@@ -74,7 +74,6 @@
             };
 
             SBJson5Parser *parser = [[SBJson5Parser alloc] initWithBlock:block
-                                                            processBlock:nil
                                                                multiRoot:NO
                                                          unwrapRootArray:NO
                                                                 maxDepth:19
@@ -97,7 +96,6 @@
             };
 
             SBJson5Parser *parser = [[SBJson5Parser alloc] initWithBlock:block
-                                                            processBlock:nil
                                                                multiRoot:NO
                                                          unwrapRootArray:NO
                                                                 maxDepth:19

--- a/Tests/MainSuite.m
+++ b/Tests/MainSuite.m
@@ -117,7 +117,6 @@ static NSString *chomp(NSString *str) {
             id parser = [[SBJson5Parser alloc] initWithBlock:^(id o, BOOL *string) {
                 XCTFail(@"%@ - %@", o, [[inpath pathComponents] lastObject]);
                 }
-                                                processBlock:nil
                                                    multiRoot:NO
                                              unwrapRootArray:NO
                                                     maxDepth:3


### PR DESCRIPTION
I have come to believe it distracts from SBJson's core purpose: to parse
& generate JSON. Thus this removes the untested processBlock code, which
fixes #241

SBJson actually has two parsers, a low-level stream parser and a
higher-level block interface. You can use the stream parser to implement
the processBlock interface yourself, with relatively little work, if you
need that.

Unfortunately the processBlock interface is poorly tested and has many
hooks into the higher-level block interface, so it would simplify the
code to remove it. This is a win for me personally, as I have very
little time to maintain SBJson these days.