### PR TITLE
Use constructor arguments instead of properties in more places

### DIFF
--- a/Classes/SBJson5Parser.m
+++ b/Classes/SBJson5Parser.m
@@ -116,8 +116,7 @@ typedef enum {
 
 	self = [super init];
 	if (self) {
-        _parser = [[SBJson5StreamParser alloc] init];
-        _parser.delegate = self;
+        _parser = [SBJson5StreamParser parserWithDelegate:self];
 
         supportManyDocuments = multiRoot;
         supportPartialDocuments = unwrapRootArray;

--- a/Classes/SBJson5StreamParser.h
+++ b/Classes/SBJson5StreamParser.h
@@ -96,17 +96,17 @@ typedef enum {
 @interface SBJson5StreamParser : NSObject
 
 @property (nonatomic, weak) SBJson5StreamParserState *state; // Private
+@property (readonly) id<SBJson5StreamParserDelegate> delegate; // Private
 
 /**
- Delegate to receive messages
+ Create a streaming parser.
 
- The object set here receives a series of messages as the parser breaks down the JSON stream
- into valid tokens.
-
- Usually this should be an instance of SBJson5Parser, but you can
- substitute your own implementation of the SBJson5StreamParserDelegate protocol if you need to.
- */
-@property (nonatomic, weak) id<SBJson5StreamParserDelegate> delegate;
+ @param delegate Receives a series of messages as the parser breaks down
+ the JSON stream into valid tokens. Usually this would be an instance of
+ SBJson5Parser, but you can substitute your own implementation of the
+ SBJson5StreamParserDelegate protocol if you need to.
+*/
++ (id)parserWithDelegate:(id<SBJson5StreamParserDelegate>)delegate;
 
 /**
  Parse some JSON

--- a/Classes/SBJson5StreamParser.m
+++ b/Classes/SBJson5StreamParser.m
@@ -41,17 +41,26 @@
 #define SBStringIsSurrogateHighCharacter(character) ((character >= 0xD800UL) && (character <= 0xDBFFUL))
 
 @implementation SBJson5StreamParser {
-@private
     SBJson5StreamTokeniser *tokeniser;
     BOOL stopped;
     NSMutableArray *_stateStack;
+    __weak id<SBJson5StreamParserDelegate> _delegate;
 }
 
 #pragma mark Housekeeping
 
 - (id)init {
+    return [self initWithDelegate:nil];
+}
+
++ (id)parserWithDelegate:(id<SBJson5StreamParserDelegate>)delegate {
+    return [[self alloc] initWithDelegate:delegate];
+}
+
+- (id)initWithDelegate:(id<SBJson5StreamParserDelegate>)delegate {
     self = [super init];
     if (self) {
+        _delegate = delegate;
         _stateStack = [[NSMutableArray alloc] initWithCapacity:32];
         _state = [SBJson5StreamParserStateStart sharedInstance];
         tokeniser = [[SBJson5StreamTokeniser alloc] init];

--- a/Classes/SBJson5StreamWriter.h
+++ b/Classes/SBJson5StreamWriter.h
@@ -105,44 +105,31 @@
 @property (nonatomic, readonly, strong) NSMutableArray *stateStack; // Internal
 
 /**
- delegate to receive JSON output
- Delegate that will receive messages with output.
+ Create a JSON stream writer
+
+ @param delegate Delegate that will receive messages with output.
+
+ @param maxDepth If the input is nested deeper than this the input will be
+ deemed to be malicious and the parser returns nil, signalling an error.
+ ("Nested too deep".) You can turn off this security feature by setting the
+ maxDepth to 0.
+
+ @param humanReadable If YES, produces human-readable output with linebreaks
+ and indentation.
+
+ @param sortKeys Whether or not to sort the dictionary keys in the output.
+ (Useful if you need to compare two structures.)
+
+ @param sortKeysComparator A custom comparator to sort dictionary keys when @p
+ sortKeys is YES. If nil, @selector(compare:) is used for sorting.
+
  */
-@property (nonatomic, weak) id<SBJson5StreamWriterDelegate> delegate;
 
-/**
- The maximum depth.
-
- Defaults to 512. If the input is nested deeper than this the input will be deemed to be
- malicious and the parser returns nil, signalling an error. ("Nested too deep".) You can
- turn off this security feature by setting the maxDepth value to 0.
- */
-@property(nonatomic) NSUInteger maxDepth;
-
-/**
- Whether we are generating human-readable (multi line) JSON.
-
- Set whether or not to generate human-readable JSON. The default is NO, which produces
- JSON without any whitespace between tokens. If set to YES, generates human-readable
- JSON with line breaks after each array value and dictionary key/value pair, indented two
- spaces per nesting level.
- */
-@property(nonatomic) BOOL humanReadable;
-
-/**
- Whether or not to sort the dictionary keys in the output.
-
- If this is set to YES, the dictionary keys in the JSON output will be in sorted order.
- (This is useful if you need to compare two structures, for example.) The default is NO.
- */
-@property(nonatomic) BOOL sortKeys;
-
-/**
- An optional comparator to be used if sortKeys is YES.
-
- If this is nil, sorting will be done via @selector(compare:).
- */
-@property (nonatomic, copy) NSComparator sortKeysComparator;
++ (id)writerWithDelegate:(id<SBJson5StreamWriterDelegate>)delegate
+                maxDepth:(NSUInteger)maxDepth
+           humanReadable:(BOOL)humanReadable
+                sortKeys:(BOOL)sortKeys
+      sortKeysComparator:(NSComparator)sortKeysComparator;
 
 /// Contains the error description after an error has occurred.
 @property (nonatomic, copy) NSString *error;

--- a/Classes/SBJson5StreamWriter.m
+++ b/Classes/SBJson5StreamWriter.m
@@ -43,7 +43,12 @@ static NSNumber *kPositiveInfinity;
 static NSNumber *kNegativeInfinity;
 
 
-@implementation SBJson5StreamWriter
+@implementation SBJson5StreamWriter {
+    BOOL _sortKeys, _humanReadable;
+    NSUInteger _maxDepth;
+    __weak id<SBJson5StreamWriterDelegate> _delegate;
+    NSComparator _sortKeysComparator;
+}
 
 + (void)initialize {
     kPositiveInfinity = [NSNumber numberWithDouble:+HUGE_VAL];
@@ -55,10 +60,34 @@ static NSNumber *kNegativeInfinity;
 #pragma mark Housekeeping
 
 - (id)init {
+    @throw @"Not Implemented";
+}
+
++ (id)writerWithDelegate:(id<SBJson5StreamWriterDelegate>)delegate
+                maxDepth:(NSUInteger)maxDepth
+           humanReadable:(BOOL)humanReadable
+                sortKeys:(BOOL)sortKeys
+      sortKeysComparator:(NSComparator)sortKeysComparator {
+    return [[self alloc] initWithDelegate:delegate
+                                 maxDepth:maxDepth
+                            humanReadable:humanReadable
+                                 sortKeys:sortKeys
+                       sortKeysComparator:sortKeysComparator];
+}
+
+- (id)initWithDelegate:(id<SBJson5StreamWriterDelegate>)delegate
+              maxDepth:(NSUInteger)maxDepth
+         humanReadable:(BOOL)humanReadable
+              sortKeys:(BOOL)sortKeys
+    sortKeysComparator:(NSComparator)sortKeysComparator {
 	self = [super init];
 	if (self) {
-		_maxDepth = 32u;
-        _stateStack = [[NSMutableArray alloc] initWithCapacity:_maxDepth];
+        _delegate = delegate;
+		_maxDepth = maxDepth;
+        _sortKeys = sortKeys;
+        _humanReadable = humanReadable;
+        _sortKeysComparator = sortKeysComparator;
+        _stateStack = [[NSMutableArray alloc] initWithCapacity:maxDepth];
         _state = [SBJson5StreamWriterStateStart sharedInstance];
         cache = [[NSMutableDictionary alloc] initWithCapacity:32];
     }

--- a/Classes/SBJson5Writer.h
+++ b/Classes/SBJson5Writer.h
@@ -39,13 +39,53 @@
 @interface SBJson5Writer : NSObject
 
 /**
- The maximum depth.
+ Create a JSON Writer instance.
 
- Defaults to 32. If the input is nested deeper than this the input will be deemed to be
- malicious and the parser returns nil, signalling an error. ("Nested too deep".) You can
- turn off this security feature by setting the maxDepth value to 0.
+ @param maxDepth If the input is nested deeper than this the input will be
+ deemed to be malicious and the parser returns nil, signalling an error.
+ ("Nested too deep".) You can turn off this security feature by setting the
+ maxDepth value to 0. Defaults to 32.
+
+ @param humanReadable Whether we are generating human-readable (multi line)
+ JSON. If set to YES, generates human-readable JSON with line breaks after
+ each array value and dictionary key/value pair, indented two spaces per
+ nesting level. The default is NO, which produces JSON without any whitespace.
+ (Except inside strings.)
+
+ @param sortKeys Whether to sort the dictionary keys in the output.
+ The default is to not sort the keys.
+
+ @see -writerWithMaxDepth:humanReadable:customSortKeysComparator:
  */
-@property(nonatomic) NSUInteger maxDepth;
++ (id)writerWithMaxDepth:(NSUInteger)maxDepth
+           humanReadable:(BOOL)humanReadable
+                sortKeys:(BOOL)sortKeys;
+
+
+/**
+ Create a JSON Writer instance.
+
+ @param maxDepth If the input is nested deeper than this the input will be
+ deemed to be malicious and the parser returns nil, signalling an error.
+ ("Nested too deep".) You can turn off this security feature by setting the
+ maxDepth value to 0. Defaults to 32.
+
+ @param humanReadable Whether we are generating human-readable (multi line)
+ JSON. If set to YES, generates human-readable JSON with line breaks after
+ each array value and dictionary key/value pair, indented two spaces per
+ nesting level. The default is NO, which produces JSON without any whitespace.
+ (Except inside strings.)
+
+ @param sortKeysComparator Use this if you want a custom sort order for your
+ dictionary keys.
+
+ @see -writerWithMaxDepth:humanReadable:sortKeys: if you just care about sort
+ order being stable.
+
+ */
++ (id)writerWithMaxDepth:(NSUInteger)maxDepth
+           humanReadable:(BOOL)humanReadable
+      sortKeysComparator:(NSComparator)sortKeysComparator;
 
 /**
  Return an error trace, or nil if there was no errors.
@@ -55,31 +95,6 @@
  if the call actually failed, before you know call this method.
  */
 @property (nonatomic, readonly, copy) NSString *error;
-
-/**
- Whether we are generating human-readable (multi line) JSON.
-
- Set whether or not to generate human-readable JSON. The default is NO, which produces
- JSON without any whitespace. (Except inside strings.) If set to YES, generates human-readable
- JSON with line breaks after each array value and dictionary key/value pair, indented two
- spaces per nesting level.
- */
-@property(nonatomic) BOOL humanReadable;
-
-/**
- Whether or not to sort the dictionary keys in the output.
-
- If this is set to YES, the dictionary keys in the JSON output will be in sorted order.
- (This is useful if you need to compare two structures, for example.) The default is NO.
- */
-@property(nonatomic) BOOL sortKeys;
-
-/**
- An optional comparator to be used if sortKeys is YES.
-
- If this is nil, sorting will be done via @selector(compare:).
- */
-@property (nonatomic, copy) NSComparator sortKeysComparator;
 
 /**
  Generates string with JSON representation for the given object.

--- a/Tests/MainSuite.m
+++ b/Tests/MainSuite.m
@@ -30,7 +30,7 @@ static NSString *chomp(NSString *str) {
 }
 
 - (void)setUp {
-    writer = [[SBJson5Writer alloc] init];
+    writer = [SBJson5Writer new];
     count = 0u;
 }
 
@@ -167,7 +167,7 @@ static NSString *chomp(NSString *str) {
 }
 
 - (void)testWriteError {
-    writer.maxDepth = 4u;
+    writer = [SBJson5Writer writerWithMaxDepth:4 humanReadable:NO sortKeys:NO];
 
     [self inExtForeachInSuite:@"main"
                         inext:@"plist"
@@ -181,8 +181,7 @@ static NSString *chomp(NSString *str) {
 
 
 - (void)testFormat {
-    writer.humanReadable = YES;
-    writer.sortKeys = YES;
+    writer = [SBJson5Writer writerWithMaxDepth:32 humanReadable:YES sortKeys:YES];
 
     [self inExtForeachInSuite:@"format"
                         inext:@"in"
@@ -201,11 +200,11 @@ static NSString *chomp(NSString *str) {
 }
 
 - (void)testComparatorSort {
-    writer.humanReadable = YES;
-    writer.sortKeys = YES;
-    writer.sortKeysComparator = ^(id obj1, id obj2) {
-        return [obj1 compare:obj2 options:NSCaseInsensitiveSearch|NSLiteralSearch];
-    };
+    writer = [SBJson5Writer writerWithMaxDepth:32
+                                 humanReadable:YES
+                            sortKeysComparator:^(id obj1, id obj2) {
+                          return [obj1 compare:obj2 options:NSCaseInsensitiveSearch|NSLiteralSearch];
+                      }];
 
     [self inExtForeachInSuite:@"comparatorsort"
                         inext:@"in"

--- a/Tests/StreamSuite.m
+++ b/Tests/StreamSuite.m
@@ -156,7 +156,11 @@ static NSError *error;
 }
 
 - (void)testWriteToStream {
-    SBJson5StreamWriter *streamWriter = [[SBJson5StreamWriter alloc] init];
+    SBJson5StreamWriter *streamWriter = [SBJson5StreamWriter writerWithDelegate:nil
+                                                                       maxDepth:32
+                                                                  humanReadable:NO
+                                                                       sortKeys:NO
+                                                             sortKeysComparator:nil];
 
     XCTAssertTrue([streamWriter writeArray:[NSArray array]]);
 


### PR DESCRIPTION
**Move away from properties for the Writer**
Settable properties implies that we can change writer properties during
writing, which is not a great idea. So set properties only in the constructor.

**Change stream writer to take read-only properties in constructor**

**Use constructor arguments rather than properties in stream parser**