### PR TITLE
once bitten, twice shy: drop codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,6 @@ jobs:
                     -scheme <<parameters.scheme>>
                     -destination "<<parameters.destination>>"
                     | xcpretty
-                environment:
-                    GCC_INSTRUMENT_PROGRAM_FLOW_ARCS: YES
-                    GCC_GENERATE_TEST_COVERAGE_FILES: YES
-            - run: bash <(curl -s https://codecov.io/bash)
 
     pod-lib-lint:
         executor: default


### PR DESCRIPTION
This repo changes so rarely, it's not worth my time hardening the
process for doing code coverage more safely.