### PR TITLE
Add guard for theoretical buffer overflow when formatting numbers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
     default:
         macos:
-            xcode: 11.3.1
+            xcode: 11.7.0
 
 workflows:
     publish:

--- a/Classes/SBJson5StreamWriter.m
+++ b/Classes/SBJson5StreamWriter.m
@@ -490,9 +490,11 @@ static const char *strForChar(int c) {
         }
 	}
 
-    // It is always safe to cast `len` to NSUInteger here, because
-    // snprintf above guarantees its range is in the range 0 to 128
-    // (the length of the `num` buffer).
+	if ((NSUInteger)len >= sizeof num) {
+		self.error = @"Number-string overflow";
+		return NO;
+	}
+
 	[_delegate writer:self appendBytes:num length: (NSUInteger)len];
 	[_state transitionState:self];
 	return YES;


### PR DESCRIPTION
I was wrong in the previous comment in this code. `snprintf` returns the length *it would have written* if the buffer was big enough, which you can use to detect overflow.

I can't actually see how an overflow can occur here in practice, but I happened to notice this and thought I'd correct it for the record.