### PR TITLE
Guard proxyForJson recursion against stack overflow

### DIFF
--- a/Classes/SBJson5StreamWriter.m
+++ b/Classes/SBJson5StreamWriter.m
@@ -154,6 +154,7 @@
     BOOL _sortKeys, _humanReadable;
     NSNumber *kTrue, *kFalse, *kPositiveInfinity, *kNegativeInfinity;
     NSUInteger _maxDepth;
+    NSUInteger _proxyDepth;
     __weak id<SBJson5StreamWriterDelegate> _delegate;
     NSComparator _sortKeysComparator;
 }
@@ -197,6 +198,7 @@
 
         _delegate = delegate;
 		_maxDepth = maxDepth;
+        _proxyDepth = 0;
         _sortKeys = sortKeys;
         _humanReadable = humanReadable;
         _sortKeysComparator = sortKeysComparator;
@@ -362,8 +364,15 @@
 		return [self writeNull];
 
 	} else if ([o respondsToSelector:@selector(proxyForJson)]) {
-		return [self writeValue:[o proxyForJson]];
-	}
+        if (_maxDepth && _proxyDepth > _maxDepth) {
+            self.error = @"proxyForJson nested too deep";
+            return NO;
+        }
+        _proxyDepth++;
+        BOOL result = [self writeValue:[o proxyForJson]];
+        _proxyDepth--;
+        return result;
+    }
 
 	self.error = [NSString stringWithFormat:@"JSON serialisation not supported for %@", [o class]];
 	return NO;

--- a/Tests/ProxyTest.m
+++ b/Tests/ProxyTest.m
@@ -60,6 +60,15 @@
 }
 @end
 
+@interface Cyclic : NSObject
+@end
+
+@implementation Cyclic
+- (id)proxyForJson {
+    return self;
+}
+@end
+
 @implementation NSDate (Private)
 - (id)proxyForJson {
     return [NSArray arrayWithObject:[self description]];
@@ -105,5 +114,12 @@
     XCTAssertNotNil([writer stringWithObject:[NSDate date]]);
 }
 
+- (void)testCyclicProxyForJsonReturnsErrorNotCrash {
+    SBJson5Writer *w = [SBJson5Writer writerWithMaxDepth:4
+                                           humanReadable:NO
+                                                sortKeys:NO];
+    XCTAssertNil([w stringWithObject:[Cyclic new]]);
+    XCTAssertEqualObjects(w.error, @"proxyForJson nested too deep");
+}
 
 @end


### PR DESCRIPTION
## Background

Security review finding: proxyForJson infinite recursion / stack overflow.

writeValue: recursed through proxyForJson with no depth limit or cycle detection. A self-referencing or cyclic object graph would cause unbounded recursion and a stack overflow crash.

## Proposed changes

Track proxy indirection depth alongside the existing maxDepth limit and reject chains that exceed it. This gives callers the same protection they already have for structural nesting.

## What's the possible impact to customers?

None. This only adds a defence for an edge case that previously crashed the process. Valid proxy chains (which don't cycle) continue to work exactly as before.