### PR TITLE
Fix --max-depth CLI argument parsing

### DIFF
--- a/sbjson/main.m
+++ b/sbjson/main.m
@@ -21,7 +21,7 @@ void usage() {
     puts("    Accept multiple top-level JSON inputs");
     puts("  --unwrap-root, -u");
     puts("    Unwrap top-level arrays");
-    puts("  --max-depth INT, -m INT");
+    puts("  --max-depth INT, -d INT");
     puts("    Change the max recursion limit to INT (default: 32)");
     puts("  --sort-keys, -s");
     puts("    Sort dictionary keys in output");
@@ -52,7 +52,17 @@ int main(int argc, const char * argv[]) {
             } else if ([arg isEqualToString:@"--unwrap-root"] || [arg isEqualToString:@"-u"]) {
                 unwrapRoot = YES;
             } else if ([arg isEqualToString:@"--max-depth"] || [arg isEqualToString:@"-d"]) {
-                maxDepth = [[enumerator nextObject] unsignedIntegerValue];
+                id depthArg = [enumerator nextObject];
+                if (!depthArg) {
+                    fprintf(stderr, "Error: --max-depth requires a numeric argument\n");
+                    exit(1);
+                }
+                NSInteger val = [depthArg integerValue];
+                if (val < 1) {
+                    fprintf(stderr, "Error: --max-depth must be a positive integer, got '%s'\n", [depthArg UTF8String]);
+                    exit(1);
+                }
+                maxDepth = (NSUInteger)val;
             } else if ([arg isEqualToString:@"--sort-keys"] || [arg isEqualToString:@"-s"]) {
                 sortKeys = YES;
             } else if ([arg isEqualToString:@"--human-readable"] || [arg isEqualToString:@"-r"]) {


### PR DESCRIPTION
## Background

Security review finding: --max-depth CLI argument silently accepted missing or invalid values, defaulting to 0 which disables the depth guard. Help text also had a duplicate short-flag conflict with -m.

## Proposed changes

- Fix help text: --max-depth uses -d, not -m (which was already claimed by --multi-root)
- Validate the argument exists and is a positive integer
- Print a clear error message and exit on failure

Before:
  - `--max-depth` with no argument: silent 0 (unlimited)
  - `--max-depth abc`: silent 0 (unlimited)
  - `--max-depth 0`: silent 0 (unlimited)

After:
  All of the above print an error to stderr and exit(1).