### PR TITLE
Detect integer overflow in number parsing and fall through to double

### DIFF
--- a/Classes/SBJson5StreamParser.m
+++ b/Classes/SBJson5StreamParser.m
@@ -573,13 +573,22 @@
                 case sbjson5_token_integer: {
                     const int UNSIGNED_LONG_LONG_MAX_DIGITS = 20;
                     if (token_len <= UNSIGNED_LONG_LONG_MAX_DIGITS) {
-                        if (*token == '-')
-                            [_delegate parserFoundNumber:@(strtoll(token, NULL, 10))];
-                        else
-                            [_delegate parserFoundNumber:@(strtoull(token, NULL, 10))];
-                                
-                        [_state parser:self shouldTransitionTo:tok];
-                        break;
+                        errno = 0;
+                        if (*token == '-') {
+                            long long val = strtoll(token, NULL, 10);
+                            if (errno != ERANGE) {
+                                [_delegate parserFoundNumber:@(val)];
+                                [_state parser:self shouldTransitionTo:tok];
+                                break;
+                            }
+                        } else {
+                            unsigned long long val = strtoull(token, NULL, 10);
+                            if (errno != ERANGE) {
+                                [_delegate parserFoundNumber:@(val)];
+                                [_state parser:self shouldTransitionTo:tok];
+                                break;
+                            }
+                        }
                     }
                 }
                     // FALL THROUGH

--- a/Tests/DecimalSuite.m
+++ b/Tests/DecimalSuite.m
@@ -89,4 +89,57 @@ static NSString *chomp(NSString *str) {
     XCTAssertEqual([parser parse:jsonData], SBJson5ParserComplete);
 }
 
+- (void)testIntegerOverflowFallsThroughToDouble {
+    // 20-digit number larger than ULLONG_MAX (18446744073709551615).
+    // Without fix: strtoull silently saturates to ULLONG_MAX.
+    // With fix: errno checked, falls through to strtod.
+    NSString *json = @"[99999999999999999999]";
+    id parser = [SBJson5Parser parserWithBlock:^(id value, BOOL *stop) {
+        NSNumber *num = value[0];
+        XCTAssertNotEqual([num unsignedLongLongValue], ULLONG_MAX);
+        XCTAssertEqual([num objCType][0], 'd');
+    } errorHandler:^(NSError *error) {
+        XCTFail(@"%@", error);
+    }];
+    XCTAssertEqual([parser parse:[json dataUsingEncoding:NSUTF8StringEncoding]], SBJson5ParserComplete);
+}
+
+- (void)testNegativeIntegerOverflowFallsThroughToDouble {
+    // Number that exceeds the 20-digit guard to verify negative
+    // fallthrough to strtod works at all.
+    NSString *json = @"[-123456789012345678901]";
+    id parser = [SBJson5Parser parserWithBlock:^(id value, BOOL *stop) {
+        NSNumber *num = value[0];
+        XCTAssertEqual([num objCType][0], 'd');
+    } errorHandler:^(NSError *error) {
+        XCTFail(@"%@", error);
+    }];
+    XCTAssertEqual([parser parse:[json dataUsingEncoding:NSUTF8StringEncoding]], SBJson5ParserComplete);
+}
+
+- (void)testLargeIntegerWithinRangeUsesFastPath {
+    // 20-digit number that fits within ULLONG_MAX range.
+    NSString *json = @"[10000000000000000000]";
+    id parser = [SBJson5Parser parserWithBlock:^(id value, BOOL *stop) {
+        NSNumber *num = value[0];
+        XCTAssertEqual([num unsignedLongLongValue], 10000000000000000000ULL);
+        XCTAssertEqual([num objCType][0], 'Q');
+    } errorHandler:^(NSError *error) {
+        XCTFail(@"%@", error);
+    }];
+    XCTAssertEqual([parser parse:[json dataUsingEncoding:NSUTF8StringEncoding]], SBJson5ParserComplete);
+}
+
+- (void)testSmallIntegerStillUsesFastPath {
+    NSString *json = @"[42]";
+    id parser = [SBJson5Parser parserWithBlock:^(id value, BOOL *stop) {
+        NSNumber *num = value[0];
+        XCTAssertEqual([num longLongValue], 42);
+        XCTAssertNotEqual([num objCType][0], 'd');
+    } errorHandler:^(NSError *error) {
+        XCTFail(@"%@", error);
+    }];
+    XCTAssertEqual([parser parse:[json dataUsingEncoding:NSUTF8StringEncoding]], SBJson5ParserComplete);
+}
+
 @end


### PR DESCRIPTION
## Background

Security review finding: strtoll/strtoull silently saturate to ±LLONG_MAX/ULLONG_MAX on overflow. The 20-digit guard catches numbers longer than 20 digits but allows overflow within that bound.

For example, `99999999999999999999` (20 digits) exceeds ULLONG_MAX (18446744073709551615) and silently produces ULLONG_MAX with no error signal.

## Proposed changes

Clear errno before calling strtoll/strtoull and check for ERANGE after. On overflow, fall through to strtod (via the existing FALL THROUGH to the real-number path) so the value retains its approximate magnitude rather than silently saturating.

## What other system does it impact?

None.

## Deployment considerations

Stacked on top of the run-decimalsuite branch (PR #306). Merge that first.