### PR TITLE
Replace bare-string @throw with NSAssert in dispatch paths

### DIFF
--- a/Classes/SBJson5StreamParser.m
+++ b/Classes/SBJson5StreamParser.m
@@ -641,7 +641,7 @@
         case '0' ... '9': ch += c - '0'; break;
         case 'a' ... 'f': ch += 10 + c - 'a'; break;
         case 'A' ... 'F': ch += 10 + c - 'A'; break;
-        default: @throw @"FUT FUT FUT";
+        default: NSAssert(0, @"Unexpected hex digit");
         }
     }
     return ch;
@@ -674,7 +674,7 @@
                 }
                 break;
             }
-            default: @throw @"FUT FUT FUT";
+            default: NSAssert(0, @"Unexpected escape character");
             }
             break;
         }


### PR DESCRIPTION
Two dispatch paths in SBJson5StreamParser used bare @throw with a dummy string for unreachable default cases. Since these paths cannot be reached from external input (the tokeniser pre-validates all input), these were safety nets for programming bugs. A bare- string @throw is non-standard and would crash the process without a useful message.

## Proposed changes

Replace with NSAssert(0, ...) for a clean abort with a descriptive assertion message.